### PR TITLE
Change the parser to take in Japanese

### DIFF
--- a/src/main/java/seedu/address/commons/util/RegexUtil.java
+++ b/src/main/java/seedu/address/commons/util/RegexUtil.java
@@ -1,0 +1,35 @@
+package seedu.address.commons.util;
+
+/**
+ * A container for different regex expressions to check whether the input is valid or not.
+ */
+public class RegexUtil {
+
+    // Miscellaneous regex expressions
+    public static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
+    // Original regex expression for AB3, for reference purposes
+    /*
+     * The first character of the address and name must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String REGEX_AB3_ADDRESS = "[^\\s].*";
+    public static final String REGEX_AB3_NAME = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String REGEX_AB3_EMAIL = getAb3EmailRegex();
+    public static final String REGEX_AB3_PHONE = "\\d{3,}";
+    public static final String REGEX_AB3_TAG = "\\p{Alnum}+";
+
+    /**
+     * Gets the regex expression for AB3 email model.
+     *
+     * @return The regex expression for AB3 email model.
+     */
+    private static String getAb3EmailRegex() {
+        // alphanumeric and special characters
+        final String localPartRegex = "^[\\w" + SPECIAL_CHARACTERS + "]+";
+        final String domainFirstCharacterRegex = "[^\\W_]"; // alphanumeric characters except underscore
+        final String domainMiddleRegex = "[a-zA-Z0-9.-]*"; // alphanumeric, period and hyphen
+        final String domainLastCharacterRegex = "[^\\W_]$";
+        return localPartRegex + "@"
+                + domainFirstCharacterRegex + domainMiddleRegex + domainLastCharacterRegex;
+    }
+}

--- a/src/main/java/seedu/address/commons/util/RegexUtil.java
+++ b/src/main/java/seedu/address/commons/util/RegexUtil.java
@@ -7,6 +7,7 @@ public class RegexUtil {
 
     // Miscellaneous regex expressions
     public static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
+
     // Original regex expression for AB3, for reference purposes
     /*
      * The first character of the address and name must not be a whitespace,
@@ -17,6 +18,19 @@ public class RegexUtil {
     public static final String REGEX_AB3_EMAIL = getAb3EmailRegex();
     public static final String REGEX_AB3_PHONE = "\\d{3,}";
     public static final String REGEX_AB3_TAG = "\\p{Alnum}+";
+
+    // Regex expressions that might be useful in project Weeblingo
+    public static final String REGEX_JAP_WORD =
+            "[(\\p{InHIRAGANA}|\\p{InKATAKANA})"
+            + "|\\p{InCJK_Unified_Ideographs}}]*"; // There should be no spaces in Jap words. \\w at the end?
+    public static final String REGEX_JAP_SENTENCE =
+            "[(\\p{InHIRAGANA}|\\p{InKATAKANA})|\\p{InCJK_Unified_Ideographs}|"
+            + "\\p{InCJK_Symbols_and_Punctuation}]"
+            + "[(\\p{InHIRAGANA}|\\p{InKATAKANA})|\\p{InCJK_Unified_Ideographs}|"
+                    + "\\p{InCJK_Symbols_and_Punctuation} ]*"; // The first character cannot be space. \\w at the end?
+    public static final String REGEX_ENG_WORD = "[\\p{Alpha}]*"; // There should be no spaces in English words.
+    public static final String REGEX_ENG_SENTENCE = "[\\p{Alpha}][\\p{Punct}]"
+            + "[\\p{Alpha}][\\p{Punct} ]*"; // The first character cannot be space.
 
     /**
      * Gets the regex expression for AB3 email model.

--- a/src/main/java/seedu/address/commons/util/RegexUtil.java
+++ b/src/main/java/seedu/address/commons/util/RegexUtil.java
@@ -20,19 +20,20 @@ public class RegexUtil {
     public static final String REGEX_AB3_TAG = "\\p{Alnum}+";
 
     // Regex expressions that might be useful in project Weeblingo
+    // The first character of the string to check cannot be white space
     public static final String REGEX_JAP_WORD =
             "[(\\p{InHIRAGANA}|\\p{InKATAKANA})"
             + "|\\p{InCJK_Unified_Ideographs}}]"
             + "[(\\p{InHIRAGANA}|\\p{InKATAKANA})"
-            + "|\\p{InCJK_Unified_Ideographs}}]*"; // There should be no spaces in Jap words. \\w at the end?
+            + "|\\p{InCJK_Unified_Ideographs}}]*";
     public static final String REGEX_JAP_SENTENCE =
             "[(\\p{InHIRAGANA}|\\p{InKATAKANA})|\\p{InCJK_Unified_Ideographs}|"
-            + "\\p{InCJK_Symbols_and_Punctuation}]"
+            + "\\p{InCJK_Symbols_and_Punctuation}|\\p{Alnum}|\\p{Punct}]"
             + "[(\\p{InHIRAGANA}|\\p{InKATAKANA})|\\p{InCJK_Unified_Ideographs}|"
-                    + "\\p{InCJK_Symbols_and_Punctuation} ]*"; // The first character cannot be space. \\w at the end?
-    public static final String REGEX_ENG_WORD = "[\\p{Alpha}]*"; // There should be no spaces in English words.
-    public static final String REGEX_ENG_SENTENCE = "[\\p{Alpha}][\\p{Punct}]"
-            + "[\\p{Alpha}][\\p{Punct} ]*"; // The first character cannot be space.
+                    + "\\p{InCJK_Symbols_and_Punctuation}|\\p{Alnum}|\\p{Punct} ]*";
+    public static final String REGEX_ENG_WORD = "[\\p{Alpha}][\\p{Alpha}]*";
+    public static final String REGEX_ENG_SENTENCE = "[\\p{Alnum}|\\p{Punct}]"
+            + "[\\p{Alnum}|\\p{Punct} ]*";
 
     /**
      * Gets the regex expression for AB3 email model.

--- a/src/main/java/seedu/address/commons/util/RegexUtil.java
+++ b/src/main/java/seedu/address/commons/util/RegexUtil.java
@@ -22,6 +22,8 @@ public class RegexUtil {
     // Regex expressions that might be useful in project Weeblingo
     public static final String REGEX_JAP_WORD =
             "[(\\p{InHIRAGANA}|\\p{InKATAKANA})"
+            + "|\\p{InCJK_Unified_Ideographs}}]"
+            + "[(\\p{InHIRAGANA}|\\p{InKATAKANA})"
             + "|\\p{InCJK_Unified_Ideographs}}]*"; // There should be no spaces in Jap words. \\w at the end?
     public static final String REGEX_JAP_SENTENCE =
             "[(\\p{InHIRAGANA}|\\p{InKATAKANA})|\\p{InCJK_Unified_Ideographs}|"

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,6 +43,8 @@ public class ParserUtil {
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
+        // It is possible to get empty string "" for trimmedName,
+        // but this case will be handled by Name.isValidName(String test)
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.RegexUtil;
+
 /**
  * Represents a Person's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
@@ -11,12 +13,7 @@ public class Address {
 
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
-
+    public static final String VALIDATION_REGEX = RegexUtil.REGEX_AB3_ADDRESS;
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -3,29 +3,24 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.RegexUtil;
+
 /**
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {
 
-    private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"
+            + "the parentheses, (" + RegexUtil.SPECIAL_CHARACTERS + ") .\n"
             + "2. This is followed by a '@' and then a domain name. "
             + "The domain name must:\n"
             + "    - be at least 2 characters long\n"
             + "    - start and end with alphanumeric characters\n"
             + "    - consist of alphanumeric characters, a period or a hyphen for the characters in between, if any.";
-    // alphanumeric and special characters
-    private static final String LOCAL_PART_REGEX = "^[\\w" + SPECIAL_CHARACTERS + "]+";
-    private static final String DOMAIN_FIRST_CHARACTER_REGEX = "[^\\W_]"; // alphanumeric characters except underscore
-    private static final String DOMAIN_MIDDLE_REGEX = "[a-zA-Z0-9.-]*"; // alphanumeric, period and hyphen
-    private static final String DOMAIN_LAST_CHARACTER_REGEX = "[^\\W_]$";
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@"
-            + DOMAIN_FIRST_CHARACTER_REGEX + DOMAIN_MIDDLE_REGEX + DOMAIN_LAST_CHARACTER_REGEX;
+    public static final String VALIDATION_REGEX = RegexUtil.REGEX_AB3_EMAIL;
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -3,6 +3,9 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.RegexUtil;
+
+
 /**
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
@@ -12,12 +15,7 @@ public class Name {
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
-
+    public static final String VALIDATION_REGEX = RegexUtil.REGEX_AB3_NAME;
     public final String fullName;
 
     /**
@@ -55,5 +53,4 @@ public class Name {
     public int hashCode() {
         return fullName.hashCode();
     }
-
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -27,5 +27,4 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
                 || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.RegexUtil;
+
 /**
  * Represents a Person's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
@@ -12,7 +14,7 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String VALIDATION_REGEX = RegexUtil.REGEX_AB3_PHONE;
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -3,6 +3,8 @@ package seedu.address.model.tag;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.RegexUtil;
+
 /**
  * Represents a Tag in the address book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
@@ -10,7 +12,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = RegexUtil.REGEX_AB3_TAG;
 
     public final String tagName;
 

--- a/src/test/java/seedu/address/commons/util/RegexUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/RegexUtilTest.java
@@ -1,14 +1,9 @@
 package seedu.address.commons.util;
 
-// import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.Test;
-
-import java.io.FileNotFoundException;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 public class RegexUtilTest {
 
@@ -70,5 +65,85 @@ public class RegexUtilTest {
         assertFalse("weather".matches(regex));
         assertFalse("天123気weather".matches(regex));
         assertFalse("天気Ä".matches(regex));
+    }
+
+    // ---------------- Tests for REGEX_JAP_SENTENCE --------------------------------------
+    /*
+     * Valid Jap sentences: only contains hiragana, katakana, kanji, english letters, numbers punctuations and symbols.
+     */
+    @Test
+    public void regexJapSentenceValid() {
+        String regex = RegexUtil.REGEX_JAP_SENTENCE;
+
+        assertTrue("猫になりたい。".matches(regex));
+        assertTrue("私は ただ、勉強したくないだけです。".matches(regex));
+        assertTrue("CS2103Tははははは".matches(regex));
+        assertTrue("収入は1000.25円。".matches(regex));
+        assertTrue("12345あいうえお".matches(regex));
+        assertTrue("ジンボはリンゴを食べる。".matches(regex));
+        assertTrue("。。。".matches(regex));
+    }
+
+    // ---------------- Tests for REGEX_JAP_SENTENCE --------------------------------------
+    /*
+     * Invalid Jap sentences: empty sentences, contain non-english & non-japanese & non-chinese characters
+     */
+    @Test
+    public void regexJapSentenceInvalid() {
+        String regex = RegexUtil.REGEX_JAP_SENTENCE;
+
+        assertFalse("".matches(regex));
+        assertFalse("  ".matches(regex));
+        assertFalse(" 収入は1000.25円。".matches(regex));
+        assertFalse("Glück".matches(regex));
+        assertFalse("Adiós".matches(regex));
+        assertFalse("아니요".matches(regex));
+    }
+
+    // ---------------- Tests for REGEX_ENG_WORD --------------------------------------
+    /*
+     * Both valid and invalid cases tests are here.
+     */
+    @Test
+    public void regexEngWord() {
+        String regex = RegexUtil.REGEX_ENG_WORD;
+
+        assertTrue("a".matches(regex));
+        assertTrue("A".matches(regex));
+        assertTrue("Yes".matches(regex));
+
+        assertFalse("".matches(regex));
+        assertFalse(" ".matches(regex));
+        assertFalse("No.".matches(regex));
+        assertFalse("1word".matches(regex));
+        assertFalse("two words".matches(regex));
+        assertFalse("Adiós".matches(regex));
+        assertFalse("아니요".matches(regex));
+    }
+
+    // ---------------- Tests for REGEX_ENG_SENTENCE --------------------------------------
+    /*
+     * Both valid and invalid cases tests are here.
+     */
+    @Test
+    public void regexEngSentence() {
+        String regex = RegexUtil.REGEX_ENG_SENTENCE;
+
+        assertTrue("a".matches(regex));
+        assertTrue("A".matches(regex));
+        assertTrue("Yes".matches(regex));
+        assertTrue("True.".matches(regex));
+        assertTrue("Haha means happiness.".matches(regex));
+        assertTrue("1 means one.".matches(regex));
+        assertTrue("......".matches(regex));
+        assertTrue("I ate dinner.".matches(regex));
+        assertTrue("We all agreed; it was a magnificent evening.".matches(regex));
+        assertTrue("Oh, how I'd love to go!".matches(regex));
+
+        assertFalse("".matches(regex));
+        assertFalse(" ".matches(regex));
+        assertFalse("这不对！".matches(regex));
+        assertFalse("Adiós".matches(regex));
+        assertFalse("아니요".matches(regex));
     }
 }

--- a/src/test/java/seedu/address/commons/util/RegexUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/RegexUtilTest.java
@@ -1,0 +1,74 @@
+package seedu.address.commons.util;
+
+// import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+public class RegexUtilTest {
+
+    // ---------------- Tests for REGEX_JAP_WORD --------------------------------------
+    /*
+     * Valid Jap words: only contains hiragana, katakana, and kanji
+     */
+    @Test
+    public void regexJapWordValid() {
+        String regex = RegexUtil.REGEX_JAP_WORD;
+
+        // normal hiragana
+        assertTrue("あ".matches(regex));
+        assertTrue("が".matches(regex));
+        assertTrue("っ".matches(regex));
+        assertTrue("ぴ".matches(regex));
+        assertTrue("きゅ".matches(regex));
+
+        // normal katakana
+        assertTrue("ア".matches(regex));
+        assertTrue("ザ".matches(regex));
+        assertTrue("ア".matches(regex));
+        assertTrue("ッ".matches(regex));
+        assertTrue("キュ".matches(regex));
+
+        // normal kanji
+        assertTrue("留学生".matches(regex));
+        assertTrue("私".matches(regex));
+        assertTrue("金魚".matches(regex));
+        assertTrue("天気".matches(regex));
+
+        // simple combinations
+        assertTrue("散りぬるを".matches(regex));
+        assertTrue("ツネナラムウヰノオクヤマ".matches(regex));
+        assertTrue("浅き夢見じ酔ひもせず".matches(regex));
+    }
+
+    /*
+     * Invalid Jap words: contains space, punctuation， latin and numeric characters
+     */
+    @Test
+    public void regexJapWordInvalid() {
+        String regex = RegexUtil.REGEX_JAP_WORD;
+
+        assertFalse("".matches(regex));
+        assertFalse(" ".matches(regex));
+        assertFalse(" 天気".matches(regex));
+        assertFalse("天気 ".matches(regex));
+        assertFalse("天気。".matches(regex));
+        assertFalse("天気、".matches(regex));
+        assertFalse("、天気".matches(regex));
+        assertFalse("天気 ".matches(regex));
+        assertFalse(" 天気".matches(regex));
+        assertFalse("123天気".matches(regex));
+        assertFalse("latin天気".matches(regex));
+        assertFalse("天気latin".matches(regex));
+        assertFalse("&*()(&**天気".matches(regex));
+        assertFalse("天気^&(^&&(^ ".matches(regex));
+        assertFalse("weather".matches(regex));
+        assertFalse("天123気weather".matches(regex));
+        assertFalse("天気Ä".matches(regex));
+    }
+}


### PR DESCRIPTION
The parser for AB3 rejects Japanese input. After tracing through the code base, it is found that the when a String is parsed to modify or create a `Model` (e.g. Name, Address, Email...), there is a checking in each of the `Model` that whether the String is in valid format or not, and that checking is mainly done by Regex.

To allow flexibility and ensure rigorousness of the application, in this PR I decided to:
1. Refactor code to wrap all Regex expressions of different `Model` classes inside one `RegexUtil` class. This helps maintain the Regex expressions.
2. Add Regex expressions for Japanese sentence, Japanese word, English sentence, English word. These may be helpful in the future if we want to display certain content in some of our self-defined `Model`s. E.g. `FlashCard`.
3. As Regex works in mysteriously in Java. Some tests for newly added Regex expressions are included.

The parser still cannot take in Japanese **for now**, but with the newly defined util class and some simple comparison with other classes like `Name`, `Email`... in existing AB3 code base, it should be trivial to allow parser to take in Japanese (after we have formally defined our `FlashCard` class).