### PR TITLE
Refactor delete command after pe dry run

### DIFF
--- a/src/main/java/seedu/weeblingo/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/weeblingo/logic/commands/DeleteTagCommand.java
@@ -17,9 +17,9 @@ import seedu.weeblingo.model.flashcard.Flashcard;
 import seedu.weeblingo.model.flashcard.Question;
 import seedu.weeblingo.model.tag.Tag;
 
-public class DeleteCommand extends Command {
+public class DeleteTagCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "deleteTag";
 
     public static final String MESSAGE_SUCCESS = "Tag(s) deleted successfully!";
 
@@ -37,12 +37,12 @@ public class DeleteCommand extends Command {
     private Set<Tag> tags;
 
     /**
-     * Creates a DeleteCommand representing a user command to delete tags from a flashcard.
+     * Creates a DeleteTagCommand representing a user command to delete tags from a flashcard.
      *
      * @param index The index of the flashcard to be deleted.
      * @param tags The tags to be deleted.
      */
-    public DeleteCommand(Index index, Set<Tag> tags) {
+    public DeleteTagCommand(Index index, Set<Tag> tags) {
         this.index = index;
         this.tags = tags;
     }

--- a/src/main/java/seedu/weeblingo/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/weeblingo/logic/commands/DeleteTagCommand.java
@@ -126,8 +126,8 @@ public class DeleteTagCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof DeleteCommand // instanceof handles nulls
-                && index.equals(((DeleteCommand) other).index)
-                && tags.equals(((DeleteCommand) other).tags));
+                || (other instanceof DeleteTagCommand // instanceof handles nulls
+                && index.equals(((DeleteTagCommand) other).index)
+                && tags.equals(((DeleteTagCommand) other).tags));
     }
 }

--- a/src/main/java/seedu/weeblingo/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/weeblingo/logic/parser/DeleteTagCommandParser.java
@@ -10,20 +10,20 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.weeblingo.commons.core.index.Index;
-import seedu.weeblingo.logic.commands.DeleteCommand;
+import seedu.weeblingo.logic.commands.DeleteTagCommand;
 import seedu.weeblingo.logic.parser.exceptions.ParseException;
 import seedu.weeblingo.model.tag.Tag;
 
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of DeleteCommand.
+     * Parses the given {@code String} of arguments in the context of DeleteTagCommand.
      *
      * @param args Given arguments
-     * @return The DeleteCommand
-     * @throws ParseException if the given arguments do not comply with the requirements of the DeleteCommand
+     * @return The DeleteTagCommand
+     * @throws ParseException if the given arguments do not comply with the requirements of the DeleteTagCommand
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteTagCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TAG);
@@ -33,12 +33,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE), pe);
         }
 
         Set<Tag> tags = parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).orElse(Collections.emptySet());
 
-        return new DeleteCommand(index, tags);
+        return new DeleteTagCommand(index, tags);
     }
 
     /**

--- a/src/main/java/seedu/weeblingo/logic/parser/WeeblingoParser.java
+++ b/src/main/java/seedu/weeblingo/logic/parser/WeeblingoParser.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.weeblingo.logic.commands.CheckCommand;
 import seedu.weeblingo.logic.commands.Command;
-import seedu.weeblingo.logic.commands.DeleteCommand;
+import seedu.weeblingo.logic.commands.DeleteTagCommand;
 import seedu.weeblingo.logic.commands.EndCommand;
 import seedu.weeblingo.logic.commands.ExitCommand;
 import seedu.weeblingo.logic.commands.HelpCommand;
@@ -74,8 +74,8 @@ public class WeeblingoParser {
         case TagCommand.COMMAND_WORD:
             return new TagCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+        case DeleteTagCommand.COMMAND_WORD:
+            return new DeleteTagCommandParser().parse(arguments);
 
         case ViewHistoryCommand.COMMAND_WORD:
             return new ViewHistoryCommand();

--- a/src/test/java/seedu/weeblingo/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/weeblingo/logic/commands/DeleteCommandTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.weeblingo.commons.core.index.Index;
+import seedu.weeblingo.logic.commands.exceptions.CommandException;
 import seedu.weeblingo.model.FlashcardBook;
 import seedu.weeblingo.model.Model;
 import seedu.weeblingo.model.ModelManager;
@@ -24,15 +25,15 @@ public class DeleteCommandTest {
     private ModelManager modelManager = new ModelManager(getTypicalFlashcardBook(), new UserPrefs());
 
     @Test
-    public void execute_delete_success() {
+    public void execute_delete_success() throws CommandException {
         Index targetIndex = INDEX_FIRST_FLASHCARD;
 
         Set<Tag> oneTag = new HashSet<>();
         oneTag.add(new Tag(VALID_TAG_EASY));
 
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, oneTag);
+        DeleteTagCommand deleteCommand = new DeleteTagCommand(targetIndex, oneTag);
 
-        String expectedMessage = DeleteCommand.MESSAGE_SUCCESS;
+        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS;
 
         Flashcard taggedFlashcard = new FlashcardBuilder().withUserTags(VALID_TAG_EASY).build();
         modelManager.switchModeLearn();

--- a/src/test/java/seedu/weeblingo/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/weeblingo/logic/commands/TagCommandTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.weeblingo.commons.core.index.Index;
+import seedu.weeblingo.logic.commands.exceptions.CommandException;
 import seedu.weeblingo.model.FlashcardBook;
 import seedu.weeblingo.model.Model;
 import seedu.weeblingo.model.ModelManager;
@@ -28,7 +29,7 @@ public class TagCommandTest {
     private ModelManager modelManager = new ModelManager(getTypicalFlashcardBook(), new UserPrefs());
 
     @Test
-    public void execute_tag_success() {
+    public void execute_tag_success() throws CommandException {
         Index targetIndex = INDEX_FIRST_FLASHCARD;
 
         Set<Tag> oneTag = new HashSet<>();

--- a/src/test/java/seedu/weeblingo/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/weeblingo/logic/parser/DeleteCommandParserTest.java
@@ -14,15 +14,15 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.weeblingo.commons.core.index.Index;
-import seedu.weeblingo.logic.commands.DeleteCommand;
+import seedu.weeblingo.logic.commands.DeleteTagCommand;
 import seedu.weeblingo.model.tag.Tag;
 
 public class DeleteCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT = String.format(
-            MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
+            MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE);
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private DeleteTagCommandParser parser = new DeleteTagCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
@@ -65,13 +65,13 @@ public class DeleteCommandParserTest {
         twoTags.add(new Tag(VALID_TAG_DIFFICULT));
 
         //only index provided
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_FLASHCARD, emptyTag));
+        assertParseSuccess(parser, "1", new DeleteTagCommand(INDEX_FIRST_FLASHCARD, emptyTag));
 
         //exactly one tag provided
-        assertParseSuccess(parser, "1 t/easy", new DeleteCommand(INDEX_FIRST_FLASHCARD, oneTag));
+        assertParseSuccess(parser, "1 t/easy", new DeleteTagCommand(INDEX_FIRST_FLASHCARD, oneTag));
 
         //more than one tag provided
-        assertParseSuccess(parser, "1 t/easy t/difficult", new DeleteCommand(INDEX_FIRST_FLASHCARD, twoTags));
+        assertParseSuccess(parser, "1 t/easy t/difficult", new DeleteTagCommand(INDEX_FIRST_FLASHCARD, twoTags));
     }
 
 }


### PR DESCRIPTION
Just refactors the delete command to deleteTag command, as well as the deleteCommadParser.

The command word for deleting tags is now deleteTag.

Fixes #139 